### PR TITLE
Added image-name input

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ It's 100% Open Source and licensed under the [APACHE2](LICENSE).
 
 | Name | Description | Default | Required |
 |------|-------------|---------|----------|
+| image\_name | Image name (excluding registry). Defaults to {{$organization/$repository}}. |  | false |
 | login | Docker login |  | false |
 | organization | Organization | N/A | true |
 | password | Docker password |  | false |

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
   registry:
     description: 'Docker registry'
     required: true
+  image_name:
+    description: "Image name (excluding registry). Defaults to {{$organization/$repository}}."
+    required: false
+    default: ''
   tag:
     required: true
     description: "Tag"
@@ -38,9 +42,12 @@ runs:
     - uses: cloudposse/github-action-yaml-config-query@0.1.3
       id: context
       with:
-        query: .
+        query: .${{ inputs.image_name == '' }}
         config: |-
-          image: ${{ inputs.registry }}/${{ inputs.organization }}/${{ inputs.repository }}
+          true:
+            image : ${{ inputs.registry }}/${{ inputs.organization }}/${{ inputs.repository }}
+          false:
+            image : ${{ inputs.registry }}/${{ inputs.image_name }}
 
     - name: Login
       uses: docker/login-action@v2

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -4,6 +4,7 @@
 
 | Name | Description | Default | Required |
 |------|-------------|---------|----------|
+| image\_name | Image name (excluding registry). Defaults to {{$organization/$repository}}. |  | false |
 | login | Docker login |  | false |
 | organization | Organization | N/A | true |
 | password | Docker password |  | false |


### PR DESCRIPTION
## what
* Added Image name input

## why
* Allow specifying custom image name (instead of default {org}/{repo name})
* To be consistent with https://github.com/cloudposse/github-action-docker-build-push/releases/tag/1.9.0
* To be consistent with  https://github.com/cloudposse/github-action-docker-promote/releases/tag/0.1.2
